### PR TITLE
Remove redundant command names from usage

### DIFF
--- a/cogs/game.py
+++ b/cogs/game.py
@@ -16,7 +16,7 @@ class Game(commands.Cog, Utils):
                       aliases = ["s"],
                       brief = "Displays your stats",
                       help = "Shows you the amount of credits you have, the number of emus in your storage, and the number of emus you have defense.",
-                      usage = "e!stats [@user] (if no mention is provided, then it displays your stats)"
+                      usage = "[@user] (if no mention is provided, then it displays your stats)"
 )
     async def stats(self, ctx, mention = None):
         if not mention == None:
@@ -35,7 +35,7 @@ class Game(commands.Cog, Utils):
                       aliases = ['d', 'def', 'defense', 'defence'],
                       brief = "Puts emus on defense",
                       help = "Puts emus on defense. Emus on defense can protect against attacks.",
-                      usage = "e!defend [# of emus]"
+                      usage = "[# of emus]"
 )
     async def defend(self, ctx, numemus: int):
         if not self.get_stats(ctx.author.id, 'storage') > 0:
@@ -55,7 +55,7 @@ class Game(commands.Cog, Utils):
                       aliases = ['od', 'offdef' 'offdefence', 'offdefend'],
                       brief = "Takes emus off defense",
                       help = "Takes your emus off of defense and puts them back into your storage",
-                      usage = "e!offdefense [# of emus]"
+                      usage = "[# of emus]"
 )
     async def offdefense(self, ctx, numemus: int):
         if not self.get_stats(ctx.author.id, 'defense') > 0:
@@ -75,7 +75,7 @@ class Game(commands.Cog, Utils):
                       aliases = ['a', 'at', 'atk', 'attk'],
                       brief = "Attacks other users",
                       help = "Attacks other users with the emus you have in storage. If you attack with more emus than they have on defense, then you will steal some of their credits.",
-                      usage = "e!attack [# of emus] [@user]"
+                      usage = "[# of emus] [@user]"
 )
     @commands.cooldown(1, Utils.ATTACKCOOLDOWN, BucketType.default)
     async def attack(self, ctx, numemus: int, mention: str):
@@ -115,7 +115,7 @@ class Game(commands.Cog, Utils):
                     aliases = ["b"],
                     brief = "Buys emus",
                     help = "Use this command to buy emus which go into your storage. Remember, you can only have a maximum of 20 emus.",
-                    usage = "e!buy [# of emus]",
+                    usage = "[# of emus]",
                     invoke_without_command = True,
                     case_insensitive = True
 )
@@ -169,7 +169,6 @@ class Game(commands.Cog, Utils):
                     aliases = ["r"],
                     brief = "Resets all of your stats",
                     help = "Resets all of your stats back to 0, restarting your experience with the emu bot game",
-                    usage = "e!reset",
                     invoke_without_command = True,
                     case_insensitive = True
 )

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -12,7 +12,7 @@ class Misc(commands.Cog, Utils):
                       description = "Makes the bot say whatever you say",
                       brief = "Makes the bot say whatever you say",
                       help = "Makes the bot says whatever you put after the e!say",
-                      usage = "e!say [sentence] or e!say, makes the bot say [sentence]"
+                      usage = '[sentence or "sentence"] - makes the bot say [sentence or "sentence"]'
 )
     async def say(self, ctx, *args):
         if len(args) == 0:
@@ -32,8 +32,7 @@ class Misc(commands.Cog, Utils):
                       description = "Gives an explanation to how the Emu Bot game works",
                       aliases = ['gx', 'gameexplain', 'gxplain'],
                       brief = "Gives an explanation to how the Emu Bot game works",
-                      help = "Gives an in-depth explain of how to use the Emu Bot's game commands and how the Emu Bot game works",
-                      usage = 'e!gamexplain'
+                      help = "Gives an in-depth explain of how to use the Emu Bot's game commands and how the Emu Bot game works"
 )
     async def gamexplain(self, ctx):
         embed = discord.Embed(title='Game Explanation', description='''**In the emu bot game, you gain credits by participating in chat. You can spend these credits on emus and attack your friends with them.**


### PR DESCRIPTION
In the auto-generated help command, it has the command name and then the usage, so putting the usage in it again is redundant.